### PR TITLE
Introduce @Publish<Modifier> resultBuilder to create Combine Publisher

### DIFF
--- a/Sources/XUI/Combine/CancellableBuilder.swift
+++ b/Sources/XUI/Combine/CancellableBuilder.swift
@@ -11,7 +11,7 @@
 ///
 /// Possible use case: Storing multiple cancellables in a collection
 /// without writing `.store(in:)` for each subscription separately.
-@_functionBuilder
+@resultBuilder
 public struct CancellableBuilder {
 
     public static func buildBlock(_ components: [Cancellable]...) -> [Cancellable] {

--- a/Sources/XUI/Combine/Publish.swift
+++ b/Sources/XUI/Combine/Publish.swift
@@ -1,0 +1,80 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Kraft on 04.05.21.
+//
+
+public typealias Pipeline<T> = AnyPublisher<T, Error>
+public typealias Observable<T> = AnyPublisher<T, Never>
+
+@resultBuilder
+public struct Publish<Modifier: PublishModifier> {
+
+    // MARK: Build
+
+    public static func build<P: Publisher>(
+        @Publish<Modifier> from build: () -> P
+    ) -> P {
+        build()
+    }
+
+    public static func build<Output>(
+        @Publish<Modifier> from build: () throws -> AnyPublisher<Output, Error>
+    ) -> AnyPublisher<Output, Error> {
+        do {
+            return try build()
+        } catch {
+            return Modifier.modify(Fail<Output, Error>(error: error))
+        }
+    }
+
+    // MARK: Build Block
+
+    public static func buildBlock<Output>(
+        _ component: Output
+    ) -> AnyPublisher<Output, Never> {
+        Modifier.modify(Just(component))
+    }
+
+    public static func buildBlock<Output>(
+        _ component: Output
+    ) -> AnyPublisher<Output, Error> {
+        Modifier.modify(Just(component).setFailureType(to: Error.self))
+    }
+
+    public static func buildBlock<P: Publisher>(
+        _ component: P
+    ) -> AnyPublisher<P.Output, Never> where P.Failure == Never {
+        Modifier.modify(component)
+    }
+
+    public static func buildBlock<P: Publisher>(
+        _ component: P
+    ) -> AnyPublisher<P.Output, Error> where P.Failure == Never {
+        Modifier.modify(component.setFailureType(to: Error.self))
+    }
+
+    public static func buildBlock<P: Publisher>(
+        _ component: P
+    ) -> AnyPublisher<P.Output, Error> {
+        Modifier.modify(component.mapError { $0 as Error })
+    }
+
+    // MARK: Build Either
+
+    public static func buildEither<P: Publisher>(first component: P) -> P {
+        component
+    }
+
+    public static func buildEither<P: Publisher>(second component: P) -> P {
+        component
+    }
+
+    // MARK: Build Limited Availability
+
+    public static func buildLimitedAvailability<P: Publisher>(_ component: P) -> P {
+        component
+    }
+
+}

--- a/Sources/XUI/Combine/PublishModifier.swift
+++ b/Sources/XUI/Combine/PublishModifier.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Kraft on 04.05.21.
+//
+
+public protocol PublishModifier {
+    static func modify<P: Publisher>(_ publisher: P) -> AnyPublisher<P.Output, P.Failure>
+}
+
+public struct MainQueue: PublishModifier {
+
+    public static func modify<P: Publisher>(
+        _ publisher: P
+    ) -> AnyPublisher<P.Output, P.Failure> {
+        publisher
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+}
+
+extension Never: PublishModifier {
+
+    public static func modify<P: Publisher>(
+        _ publisher: P
+    ) -> AnyPublisher<P.Output, P.Failure> {
+        publisher
+            .eraseToAnyPublisher()
+    }
+
+}


### PR DESCRIPTION
This change introduces a new result builder to allow for the simple creation of reactive APIs.

One will be able to create publishers using the following:

```swift
@Publish<MainQueue>
func fetchProject(name: String) -> Pipeline<Project> {
    if let project = cache[name] {
        project
    } else {
        URLSession.shared.dataTaskPublisher(for: request)
            .map(\.data)
            .decode(Project.self, from: JSONDecoder())
    }
}
```