### PR TITLE
removed unnecessary assertion failure by constraining generic type

### DIFF
--- a/Sources/XUI/Store/Store.swift
+++ b/Sources/XUI/Store/Store.swift
@@ -7,7 +7,7 @@
 //
 
 @propertyWrapper
-public struct Store<Model>: DynamicProperty {
+public struct Store<Model>: DynamicProperty where Model: AnyObservableObject {
 
     // MARK: Nested types
 
@@ -40,13 +40,7 @@ public struct Store<Model>: DynamicProperty {
 
     public init(wrappedValue: Model) {
         self.wrappedValue = wrappedValue
-
-        if let objectWillChange = (wrappedValue as? AnyObservableObject)?.objectWillChange {
-            self.observableObject = .init(objectWillChange: objectWillChange.eraseToAnyPublisher())
-        } else {
-            assertionFailure("Only use the `Store` property wrapper with instances conforming to `AnyObservableObject`.")
-            self.observableObject = .empty()
-        }
+        self.observableObject = .init(objectWillChange: wrappedValue.objectWillChange.eraseToAnyPublisher())
     }
 
     // MARK: Methods


### PR DESCRIPTION
The assertion failure on line 47 was necessary to make sure only `AnyObservableObject` types are used within the store. Casting was necessary because normal `ObservableObject`s have an associated type, which would make this construct almost useless.

However, we could also constrain the `Model` type such that it must always be an `AnyObservableObject` (which it always must be anyway if it is a `ViewModel` type. This removes the need for assertion failures and unexpected runtime behavior, and still prevents this type having to wrap an `ObservableObject`.